### PR TITLE
chore(deps): move onlyBuiltDependencies to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,5 @@
   "devDependencies": {
     "@playwright/test": "^1.61.1",
     "@tailwindcss/typography": "^0.5.10"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": ["esbuild", "sharp"]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+onlyBuiltDependencies:
+  - esbuild
+  - sharp


### PR DESCRIPTION
Unblocks Renovate PR #86 (pnpm v11 security bump): pnpm 11 ignores the package.json pnpm field and fails with ERR_PNpm_IGNORED_BUILDS. pnpm-workspace.yaml works on both pnpm 10 and 11. Verified locally on pnpm 10.34.4 (install + build green).