### PR TITLE
ci: smoke-check the pages.dev domain instead of the custom domain

### DIFF
--- a/.github/workflows/post-deploy-check.yml
+++ b/.github/workflows/post-deploy-check.yml
@@ -22,15 +22,21 @@ jobs:
         run: sleep 180
 
       - name: Check production routes
+        # The custom domain (necofuryai.io) sits behind the zone's bot
+        # protection, which 403s requests from datacenter IPs such as GitHub
+        # runners. The pages.dev project domain serves the same production
+        # deployment without that layer, so build/deploy breakage is still
+        # caught; DNS/WAF issues on the custom domain are out of scope here.
         run: |
           set -euo pipefail
+          base="https://necofuryai-personal-website.pages.dev"
           routes=("/" "/cv/" "/projects/" "/hobbies/" "/pr/")
           deadline=$((SECONDS + 420))
           ok=false
           while [ "$SECONDS" -lt "$deadline" ]; do
             all_good=true
             for route in "${routes[@]}"; do
-              if ! curl --fail --silent --show-error --max-time 20 "https://necofuryai.io${route}" > /dev/null; then
+              if ! curl --fail --silent --show-error --max-time 20 "${base}${route}" > /dev/null; then
                 all_good=false
                 echo "Route ${route} not healthy yet; retrying in 30s..."
                 break
@@ -43,7 +49,7 @@ jobs:
             sleep 30
           done
           if [ "$ok" != "true" ]; then
-            echo "::error::Production smoke check failed for https://necofuryai.io"
+            echo "::error::Production smoke check failed for ${base}"
             exit 1
           fi
           echo "All production routes healthy."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ In `/src/content/`:
 - VRT baselines are generated ONLY by the `VRT Update Baselines` workflow on ubuntu-24.04; never run `playwright test --update-snapshots` locally.
 - Lighthouse CI is advisory for now (tighten thresholds later).
 - Claude advisory review (`renovate-review.yml`) is optional and skips green when `CLAUDE_CODE_OAUTH_TOKEN` is absent.
-- Post-deploy `Production Smoke Check` runs on every push to `main`; recovery = Cloudflare Pages Instant Rollback.
+- Post-deploy `Production Smoke Check` runs on every push to `main` against the pages.dev project domain (the custom domain 403s datacenter IPs via bot protection); recovery = Cloudflare Pages Instant Rollback.
 - Known limitation: a Cloudflare build failure keeps serving the previous deployment; covered by Cloudflare's build-failure emails.
 
 ## Extended References

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ Both content dirs are currently EMPTY and have no rendering routes in `src/pages
 - VRT baselines are generated ONLY by the `VRT Update Baselines` workflow on ubuntu-24.04; never run `playwright test --update-snapshots` locally.
 - Lighthouse CI is advisory for now (tighten thresholds later).
 - Claude advisory review (`renovate-review.yml`) is optional and skips green when `CLAUDE_CODE_OAUTH_TOKEN` is absent.
-- Post-deploy `Production Smoke Check` runs on every push to `main`; recovery = Cloudflare Pages Instant Rollback.
+- Post-deploy `Production Smoke Check` runs on every push to `main` against the pages.dev project domain (the custom domain 403s datacenter IPs via bot protection); recovery = Cloudflare Pages Instant Rollback.
 - Known limitation: a Cloudflare build failure keeps serving the previous deployment; covered by Cloudflare's build-failure emails.
 
 ## Extended References


### PR DESCRIPTION
First real smoke run (run 28711462143) failed with curl 403 from the runner while the site returned 200 from residential IPs: zone bot protection blocks datacenter IPs. Switch monitoring to https://necofuryai-personal-website.pages.dev (verified serving production content). Also documented in CLAUDE.md/AGENTS.md; repo Issues enabled for the incident step.