### PR TITLE
chore(deps): add pnpm 11 allowBuilds alongside onlyBuiltDependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
+# Build-script allowlist in both formats: pnpm 10 reads
+# onlyBuiltDependencies, pnpm 11 reads allowBuilds (the old key was
+# removed in v11). Each version ignores the other's key.
 onlyBuiltDependencies:
   - esbuild
   - sharp
+allowBuilds:
+  esbuild: true
+  sharp: true


### PR DESCRIPTION
pnpm 11 removed onlyBuiltDependencies in favor of the allowBuilds map (https://pnpm.io/blog/releases/11.0), so PR #86 still failed after the workspace-file move. Both formats now coexist; pnpm 10 verified locally. Unblocks Renovate PR #86.